### PR TITLE
Admin: Clear audience suggestions

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -93,6 +93,8 @@ export default function Dashboard() {
   const [clearingPlayed, setClearingPlayed] = useState(false);
   const [confirmClearRequests, setConfirmClearRequests] = useState(false);
   const [clearingRequests, setClearingRequests] = useState(false);
+  const [confirmClearSuggestions, setConfirmClearSuggestions] = useState(false);
+  const [clearingSuggestions, setClearingSuggestions] = useState(false);
 
   const togglePlayed = async (songId: number, currentPlayed: boolean) => {
     await supabase.from('songs').update({ played: !currentPlayed }).eq('id', songId);
@@ -112,6 +114,14 @@ export default function Dashboard() {
     await supabase.from('requests').delete().gte('id', 0);
     setConfirmClearRequests(false);
     setClearingRequests(false);
+    fetchData();
+  };
+
+  const clearSuggestions = async () => {
+    setClearingSuggestions(true);
+    await supabase.from('suggestions').delete().gte('id', 0);
+    setConfirmClearSuggestions(false);
+    setClearingSuggestions(false);
     fetchData();
   };
 
@@ -496,6 +506,67 @@ export default function Dashboard() {
               }}
             >
               CLEAR REQUESTS
+            </button>
+          )}
+          <div style={{ width: '1px', height: '1rem', background: '#222' }} />
+          {confirmClearSuggestions ? (
+            <>
+              <span style={{ fontFamily: 'Barlow, sans-serif', fontSize: '0.75rem', color: '#f59e0b' }}>Clear all suggestions?</span>
+              <button
+                onClick={clearSuggestions}
+                disabled={clearingSuggestions}
+                style={{
+                  background: '#dc262622',
+                  color: '#dc2626',
+                  border: '1px solid #dc262644',
+                  fontFamily: 'Barlow Condensed, sans-serif',
+                  fontWeight: 700,
+                  fontSize: '0.7rem',
+                  letterSpacing: '0.06em',
+                  padding: '0.25rem 0.65rem',
+                  borderRadius: '4px',
+                  cursor: clearingSuggestions ? 'not-allowed' : 'pointer',
+                  opacity: clearingSuggestions ? 0.6 : 1,
+                }}
+              >
+                {clearingSuggestions ? 'CLEARING…' : 'YES, CLEAR'}
+              </button>
+              <button
+                onClick={() => setConfirmClearSuggestions(false)}
+                style={{
+                  background: 'transparent',
+                  color: '#444',
+                  border: '1px solid #222',
+                  fontFamily: 'Barlow Condensed, sans-serif',
+                  fontWeight: 700,
+                  fontSize: '0.7rem',
+                  letterSpacing: '0.06em',
+                  padding: '0.25rem 0.65rem',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                }}
+              >
+                CANCEL
+              </button>
+            </>
+          ) : (
+            <button
+              className="admin-btn"
+              onClick={() => setConfirmClearSuggestions(true)}
+              style={{
+                background: 'transparent',
+                color: '#555',
+                border: '1px solid #222',
+                fontFamily: 'Barlow Condensed, sans-serif',
+                fontWeight: 700,
+                fontSize: '0.7rem',
+                letterSpacing: '0.06em',
+                padding: '0.25rem 0.65rem',
+                borderRadius: '4px',
+                cursor: 'pointer',
+              }}
+            >
+              CLEAR SUGGESTIONS
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Adds a **CLEAR SUGGESTIONS** button to the admin bar on the dashboard
- Deletes all rows from the `suggestions` table, emptying the suggestions panel
- Two-step confirmation prevents accidental resets
- Admin bar now has all three controls: CLEAR PLAYED, CLEAR REQUESTS, CLEAR SUGGESTIONS

## Test plan
- [ ] Run `npm run dev`, open `/dashboard`
- [ ] Submit a suggestion on the public jukebox page
- [ ] Confirm the suggestion appears in the suggestions panel
- [ ] Click CLEAR SUGGESTIONS → confirm prompt appears
- [ ] Click CANCEL — nothing changes
- [ ] Click CLEAR SUGGESTIONS → YES, CLEAR — suggestions panel empties

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)